### PR TITLE
updated AwGo references to match new library code (issue #25)

### DIFF
--- a/update.go
+++ b/update.go
@@ -16,11 +16,11 @@ func doUpdate() error {
 
 // checkForUpdate runs "./alsf update" in the background if an update check is due.
 func checkForUpdate() error {
-	if !wf.UpdateCheckDue() || aw.IsRunning("update") {
+	if !wf.UpdateCheckDue() || wf.IsRunning("update") {
 		return nil
 	}
 	cmd := exec.Command(os.Args[0], "update")
-	return aw.RunInBackground("update", cmd)
+	return wf.RunInBackground("update", cmd)
 }
 
 // showUpdateStatus adds an "update available!" message to Script Filters if an update is available
@@ -36,7 +36,6 @@ func showUpdateStatus() {
 		wf.NewItem("An update is available!").
 			Subtitle("⇥ or ↩ to install update").
 			Valid(false).
-			Autocomplete("workflow:update").
-			Icon(updateAvailable)
+			Autocomplete("workflow:update")
 	}
 }

--- a/update.go
+++ b/update.go
@@ -36,6 +36,7 @@ func showUpdateStatus() {
 		wf.NewItem("An update is available!").
 			Subtitle("⇥ or ↩ to install update").
 			Valid(false).
-			Autocomplete("workflow:update")
+			Autocomplete("workflow:update").
+			Icon(iconUpdate)
 	}
 }

--- a/wiki.go
+++ b/wiki.go
@@ -22,13 +22,13 @@ func parseSummaryFile() []Link {
 	re := regexp.MustCompile(`\[([^\]]*)\]\(([^)]*)\)`)
 	re1 := regexp.MustCompile(`(.md)`)
 
-	var links []link
+	var links []Link
 
 	// Read file line by line and extraxt links
 	scanner := bufio.NewScanner(strings.NewReader(string(bytes)))
 	for scanner.Scan() {
 		matches := re.FindAllStringSubmatch(scanner.Text(), -1)
-		links = append(links, link{
+		links = append(links, Link{
 			uid:  matches[0][1],
 			name: matches[0][1],
 			url:  "https://wiki.nikitavoloboev.xyz/" + re1.ReplaceAllString(matches[0][2], `.html`),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request. Have any questions? Check out contributing docs. -->

## Summary
Referencing Issue #25.
This fixes the error thrown when running 
```bash
alfred build
```
due to changes in the AwGo library and updates references to the Link class to the proper case name.
<!-- Short summary, referencing related issues: Closes #00, References #00, etc. -->



## Changes
<!-- What are the changes made in this pull request? -->

- Updated AwGo library references in wiki.go and update.go to match new library code
- Fixes references to 'Link' class in wiki.go and update.go to match class name

## Notes for reviewers
Unsure of the purpose of 'Icon(updateAvailable)' in update.go and how it works. It was throwing an error 
```bash
 ./update.go:40:9: undefined: updateAvailable
```
and removing the line seems to have no impact on functionality. Any suggestions on how I should handle this?
<!-- 
Optionally mention anything you think is notable related to this PR.
Can @mention reviewers with requests, questions.
-->


